### PR TITLE
Create custom msgs

### DIFF
--- a/Utils.js
+++ b/Utils.js
@@ -1,4 +1,11 @@
-export default function checkKc(bossName, killCount, playerName) {
+/**
+ *
+ * @param bossName
+ * @param killCount
+ * @param playerName
+ * @returns
+ */
+export function checkKc(bossName, killCount, playerName) {
   const theBoys = [
     'LSX SWAP',
     'MOOREI',
@@ -20,7 +27,7 @@ export default function checkKc(bossName, killCount, playerName) {
   ]);
   const bossInterval = bossMap.get(bossName.toUpperCase());
 
-  // if KC is noteable
+  // if KC is notable
   if (bossMap.has(bossName.toUpperCase()) && killCount % bossInterval === 0)
     return true;
 
@@ -42,4 +49,40 @@ export default function checkKc(bossName, killCount, playerName) {
     return true;
   }
   return false;
+}
+
+/**
+ *
+ * @param bossName
+ * @param killCount
+ * @param playerName
+ * @param time
+ * @param isPb
+ * @param env
+ * @returns
+ */
+export function createFormData(
+  bossName,
+  killCount,
+  playerName,
+  time,
+  isPb,
+  env
+) {
+  const { KC_URL, PB_URL } = env;
+  let msgMap = new Map();
+
+  if (isPb) {
+    msgMap.set(
+      PB_URL,
+      `**${playerName}** has defeated **${bossName}** with a new personal best of **${time}**`
+    );
+  }
+
+  msgMap.set(
+    KC_URL,
+    `**${playerName}** has defeated **${bossName}** with a completion count of **${killCount}**`
+  );
+
+  return msgMap;
 }


### PR DESCRIPTION
Ran into an issue when a player achieved a personal best with it also being their 1st kill. Dink would only send the personal best message to the `KC_URL`. What should be happening in this scenario is two messages being sent to their respective URL.

- New method that creates the message and sets it to it's corresponding URL in the `msgMap`.
- Loop over the `msgMap` so that we send off each message in the scenario listed above.